### PR TITLE
adjust to host versions of docs in the same domain

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -15,7 +15,7 @@ module.exports = {
     versions: [
       {
         title: '2022',
-        path: 'https://developer-stage.adobe.com/photoshop/uxp/'
+        path: '/photoshop/uxp/'
       },
       {
         title: '2021',


### PR DESCRIPTION
## Description

adjust to host versions of docs in the same domain

## Related Issue

https://jira.corp.adobe.com/browse/PS-91383 docs should be same domain and generally should have relative paths (don't require a domain within the project generally)

## Motivation and Context

same domain, don't link to other environments

## How Has This Been Tested?

intent to test on staging before deploying to production

## Types of changes

config environment deployment related change:
NOTE relates directly to PR for 2022/current docs at https://github.com/AdobeDocs/uxp-photoshop/pull/306

## Checklist:

- [ x ] My code follows the code style of this project.
