### PR TITLE
*WIP* setup to use v1 instead of 2021, including redirecting

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,11 +14,11 @@ module.exports = {
   siteMetadata: {
     versions: [
       {
-        title: '2022',
-        path: '/photoshop/uxp/2022/'
+        title: 'v2',
+        path: '/photoshop/uxp/v2/'
       },
       {
-        title: '2021',
+        title: 'v1',
         selected: true
       }
     ],
@@ -225,5 +225,5 @@ module.exports = {
     ],
   },
   plugins: [`@adobe/gatsby-theme-aio`],
-  pathPrefix: process.env.PATH_PREFIX || "/photoshop/uxp/2021/",
+  pathPrefix: process.env.PATH_PREFIX || "/photoshop/uxp/v1/",
 };

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,49 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+<script dangerouslySetInnerHTML={{
+__html: `
+(function(){
+	// /photoshop/uxp/2022/any -> /photoshop/uxp/v2/any
+	const url = new URL(location);
+	const yearVersionPattern = /^\/photoshop\/uxp\/202([0-9])/; 
+	let { pathname } = url;
+	if(yearVersionPattern.test(pathname)){
+		url.pathname = pathname.replace(yearVersionPattern, '/photoshop/uxp/v$1');
+		location.assign(url);
+	}
+})();
+`, }} />
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        {props.preBodyComponents}
+        <div
+          key={`body`}
+          id="___gatsby"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}


### PR DESCRIPTION
## Description

*WIP* setup for v1 instead of 2021
- needs review, testing
- needs placeholder content to test representing `/202n -> /vn`

## Related Issue

PS-93332

## Motivation and Context

using standard versioning, urls and UI use major version

## How Has This Been Tested?

NOT YET. TODO

## Types of changes

needs placeholder content and checking at path `/photoshop/uxp/2021`

## Checklist:

- [ ] needs manual testing in gh-pages at path `/2021` for client-side redirect to `/v1` and `/2022` to `/v2` (within /*2 and /*1)
- [ ] test linking across/between v2 to v1
- [ ] setup http redirects after publishing for the same so we can remove the client-side redirects
