### PR TITLE
Add legal disclosure requirements for companion apps and first-launch install modal

### DIFF
--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -187,26 +187,19 @@ You will need to set your plugin manifest's minimum version depending on the hos
 - The companion app must successfully install on platforms it claims to support.
 - The companion app must be able to successfully communicate with the plugin.
 - The companion app must not cause abnormal resource usage (e.g., CPU, RAM, storage).
-- It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description:
+- It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description.
 
-  _This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._
-
-  _You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._
-
-  _Please refer to the developer’s plugin description for more information._
+| Required disclosure text (plugin description) |
+| --- |
+| _This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._<br /><br />_You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._<br /><br />_Please refer to the developer’s plugin description for more information._ |
 
 #### First-launch disclosure
 
-- The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim:
+- The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim.
 
-  _This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_
-
-  - _Read and write to files on your device_
-  - _Make and receive requests_
-  - _Access any devices present on your computer_
-  - _Generate content in your Adobe application_
-
-  _Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._
+| Required disclosure text (first-launch modal) |
+| --- |
+| _This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_<br /><br /><ul><li>Read and write to files on your device</li><li>Make and receive requests</li><li>Access any devices present on your computer</li><li>Generate content in your Adobe application</li></ul><br />_Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._ |
 
 ### User experience
 

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -189,24 +189,24 @@ You will need to set your plugin manifest's minimum version depending on the hos
 - The companion app must not cause abnormal resource usage (e.g., CPU, RAM, storage).
 - It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description:
 
-  > This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application.
-  >
-  > You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project.
-  >
-  > Please refer to the developer’s plugin description for more information.
+  _This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._
+
+  _You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._
+
+  _Please refer to the developer’s plugin description for more information._
 
 #### First-launch disclosure
 
 - The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim:
 
-  > This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:
-  >
-  > - Read and write to files on your device
-  > - Make and receive requests
-  > - Access any devices present on your computer
-  > - Generate content in your Adobe application
-  >
-  > Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information.
+  _This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_
+
+  - _Read and write to files on your device_
+  - _Make and receive requests_
+  - _Access any devices present on your computer_
+  - _Generate content in your Adobe application_
+
+  _Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._
 
 ### User experience
 

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -187,19 +187,27 @@ You will need to set your plugin manifest's minimum version depending on the hos
 - The companion app must successfully install on platforms it claims to support.
 - The companion app must be able to successfully communicate with the plugin.
 - The companion app must not cause abnormal resource usage (e.g., CPU, RAM, storage).
-- It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description.
 
-| Required disclosure text (plugin description) |
-| --- |
-| _This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._<br /><br />_You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._<br /><br />_Please refer to the developer’s plugin description for more information._ |
+It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description:
+
+_This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._
+
+_You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._
+
+_Please refer to the developer’s plugin description for more information._
 
 #### First-launch disclosure
 
-- The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim.
+The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim:
 
-| Required disclosure text (first-launch modal) |
-| --- |
-| _This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_<br /><br /><ul><li>Read and write to files on your device</li><li>Make and receive requests</li><li>Access any devices present on your computer</li><li>Generate content in your Adobe application</li></ul><br />_Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._ |
+_This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_
+
+_• Read and write to files on your device_<br />
+_• Make and receive requests_<br />
+_• Access any devices present on your computer_<br />
+_• Generate content in your Adobe application_
+
+_Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._
 
 ### User experience
 

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -187,6 +187,26 @@ You will need to set your plugin manifest's minimum version depending on the hos
 - The companion app must successfully install on platforms it claims to support.
 - The companion app must be able to successfully communicate with the plugin.
 - The companion app must not cause abnormal resource usage (e.g., CPU, RAM, storage).
+- It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description:
+
+  > This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application.
+  >
+  > You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project.
+  >
+  > Please refer to the developer’s plugin description for more information.
+
+#### First-launch disclosure
+
+- The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim:
+
+  > This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:
+  >
+  > - Read and write to files on your device
+  > - Make and receive requests
+  > - Access any devices present on your computer
+  > - Generate content in your Adobe application
+  >
+  > Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information.
 
 ### User experience
 


### PR DESCRIPTION
## Description

Adds two new requirements to the submission checklist:
1. Under "Third Party Companion Apps" — developers must include a specific legal disclosure verbatim in their plugin's description when a companion app is required.
2. A new "First-launch disclosure" section — plugins must display a modal on first install containing the legal notice covering third-party developer origin, admin password prompts, and companion app / generative AI capability disclosures.

Both disclosures are reproduced verbatim from legal as blockquotes, matching the exist formatting conventions used in this doc.

## Related Issue

N/A

## Motivation and Context

Legal requires these disclosures to be surfaced to users so that plugin submissions castandard around third-party companion apps and generative AI capabilities. This documents the requirement so plugin developers know what's expected during submission review.

## How Has This Been Tested?

Reviewed the rendered markdown for correct formatting (nested blockquotes) and verifiehe wording provided by legal exactly, with no alterations.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.