### PR TITLE
Add legal disclosure for plugins requiring a companion application

### DIFF
--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -187,26 +187,19 @@ You will need to set your plugin manifest's minimum version depending on the hos
 - The companion app must successfully install on platforms it claims to support.
 - The companion app must be able to successfully communicate with the plugin.
 - The companion app must not cause abnormal resource usage (e.g., CPU, RAM, storage).
-- It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description:
+- It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description.
 
-  _This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._
-
-  _You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._
-
-  _Please refer to the developer’s plugin description for more information._
+| Required disclosure text (plugin description) |
+| --- |
+| _This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._<br /><br />_You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._<br /><br />_Please refer to the developer’s plugin description for more information._ |
 
 #### First-launch disclosure
 
-- The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim:
+- The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim.
 
-  _This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_
-
-  - _Read and write to files on your device_
-  - _Make and receive requests_
-  - _Access any devices present on your computer_
-  - _Generate content in your Adobe application_
-
-  _Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._
+| Required disclosure text (first-launch modal) |
+| --- |
+| _This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_<br /><br /><ul><li>Read and write to files on your device</li><li>Make and receive requests</li><li>Access any devices present on your computer</li><li>Generate content in your Adobe application</li></ul><br />_Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._ |
 
 ### User experience
 

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -194,7 +194,7 @@ It is the developer's responsibility to include the following legal disclosure, 
 | --- |
 | **This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application. You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project.** |
 
-#### First-launch disclosure
+#### First-launch disclosure (optional)
 
 When a plugin that requires a companion application is launched for the first time within the host app, it should display a modal dialog. While not required, we recommend including the legal disclosure below, verbatim, within this dialog. The dialog must include a close button so users can dismiss it:
 

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -196,7 +196,7 @@ It is the developer's responsibility to include the following legal disclosure, 
 
 #### First-launch disclosure
 
-For plugins that require a companion application, it is not compulsory, but it is good practice, for the modal dialog shown the first time the plugin is launched within the host app to include the following legal disclosure, verbatim. This modal should also include a close button so the user can dismiss it:
+For plugins that require a companion application, including the following legal disclosure, verbatim, in the modal dialog shown the first time the plugin is launched within the host app is not mandatory, though it is the preferred approach. This modal should also include a close button that allows users to dismiss it:
 
 | Legal disclosure |
 | --- |

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -189,24 +189,24 @@ You will need to set your plugin manifest's minimum version depending on the hos
 - The companion app must not cause abnormal resource usage (e.g., CPU, RAM, storage).
 - It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description:
 
-  > This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application.
-  >
-  > You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project.
-  >
-  > Please refer to the developer’s plugin description for more information.
+  _This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._
+
+  _You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._
+
+  _Please refer to the developer’s plugin description for more information._
 
 #### First-launch disclosure
 
 - The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim:
 
-  > This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:
-  >
-  > - Read and write to files on your device
-  > - Make and receive requests
-  > - Access any devices present on your computer
-  > - Generate content in your Adobe application
-  >
-  > Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information.
+  _This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_
+
+  - _Read and write to files on your device_
+  - _Make and receive requests_
+  - _Access any devices present on your computer_
+  - _Generate content in your Adobe application_
+
+  _Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._
 
 ### User experience
 

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -190,24 +190,17 @@ You will need to set your plugin manifest's minimum version depending on the hos
 
 It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description:
 
-_This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._
-
-_You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._
-
-_Please refer to the developer’s plugin description for more information._
+| Legal disclosure |
+| --- |
+| **This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application. You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project.** |
 
 #### First-launch disclosure
 
-The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim:
+For plugins that require a companion application, it is not compulsory, but it is good practice, for the modal dialog shown the first time the plugin is launched within the host app to include the following legal disclosure, verbatim. This modal should also include a close button so the user can dismiss it:
 
-_This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_
-
-_• Read and write to files on your device_<br />
-_• Make and receive requests_<br />
-_• Access any devices present on your computer_<br />
-_• Generate content in your Adobe application_
-
-_Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._
+| Legal disclosure |
+| --- |
+| **This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application. You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project.** |
 
 ### User experience
 

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -187,19 +187,27 @@ You will need to set your plugin manifest's minimum version depending on the hos
 - The companion app must successfully install on platforms it claims to support.
 - The companion app must be able to successfully communicate with the plugin.
 - The companion app must not cause abnormal resource usage (e.g., CPU, RAM, storage).
-- It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description.
 
-| Required disclosure text (plugin description) |
-| --- |
-| _This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._<br /><br />_You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._<br /><br />_Please refer to the developer’s plugin description for more information._ |
+It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description:
+
+_This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application._
+
+_You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project._
+
+_Please refer to the developer’s plugin description for more information._
 
 #### First-launch disclosure
 
-- The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim.
+The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim:
 
-| Required disclosure text (first-launch modal) |
-| --- |
-| _This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_<br /><br /><ul><li>Read and write to files on your device</li><li>Make and receive requests</li><li>Access any devices present on your computer</li><li>Generate content in your Adobe application</li></ul><br />_Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._ |
+_This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:_
+
+_• Read and write to files on your device_<br />
+_• Make and receive requests_<br />
+_• Access any devices present on your computer_<br />
+_• Generate content in your Adobe application_
+
+_Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information._
 
 ### User experience
 

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -187,6 +187,26 @@ You will need to set your plugin manifest's minimum version depending on the hos
 - The companion app must successfully install on platforms it claims to support.
 - The companion app must be able to successfully communicate with the plugin.
 - The companion app must not cause abnormal resource usage (e.g., CPU, RAM, storage).
+- It is the developer's responsibility to include the following legal disclosure, verbatim, in the plugin's description:
+
+  > This plugin requires installation and use of a companion application. Companion applications may include generative AI capabilities and be able to perform actions on your behalf, including accessing your files, exporting data, and generating content in your Adobe application.
+  >
+  > You are responsible for determining whether the use of this plugin and, as applicable, its companion application, is appropriate for your project.
+  >
+  > Please refer to the developer’s plugin description for more information.
+
+#### First-launch disclosure
+
+- The first time a plugin is installed, it must display a modal dialog containing the following legal disclosure, verbatim:
+
+  > This plugin has been developed by a third-party developer and you may be asked to enter your administrator password to complete the installation. In addition, this plugin may require installation and use of a companion application, which may have generative AI capabilities and be able to perform actions on your behalf. You are responsible for determining whether the use of this plugin and any companion application is appropriate for your project. Be sure to only install plugins and companion applications from developers you trust, as they may be able to:
+  >
+  > - Read and write to files on your device
+  > - Make and receive requests
+  > - Access any devices present on your computer
+  > - Generate content in your Adobe application
+  >
+  > Adobe’s privacy policy and terms of use are not applicable to this plugin. Please refer to the developer’s plugin description and terms of service for more information.
 
 ### User experience
 

--- a/src/pages/distribution/submission-checklist/index.md
+++ b/src/pages/distribution/submission-checklist/index.md
@@ -196,7 +196,7 @@ It is the developer's responsibility to include the following legal disclosure, 
 
 #### First-launch disclosure
 
-For plugins that require a companion application, including the following legal disclosure, verbatim, in the modal dialog shown the first time the plugin is launched within the host app is not mandatory, though it is the preferred approach. This modal should also include a close button that allows users to dismiss it:
+When a plugin that requires a companion application is launched for the first time within the host app, it should display a modal dialog. While not required, we recommend including the legal disclosure below, verbatim, within this dialog. The dialog must include a close button so users can dismiss it:
 
 | Legal disclosure |
 | --- |


### PR DESCRIPTION
## Description
Adds legal disclosure guidance for plugins that require a companion application.
Includes the required disclosure text in the "Third party companion app" section
and introduces a new "First-launch disclosure (optional)" section recommending a
dismissible modal on first launch.

## Related Issue
<!-- Link the related issue here -->

## Motivation and Context
Clarifies the developer's responsibility to disclose companion app requirements
(including potential generative AI capabilities) so users can make informed decisions.

## How Has This Been Tested?
Documentation-only change. Verified rendering and formatting of the updated sections.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist:
- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.